### PR TITLE
[BUGFIX] Correctly resolve pageId from ServerRequest

### DIFF
--- a/Classes/Form/Container/InlineControlContainer.php
+++ b/Classes/Form/Container/InlineControlContainer.php
@@ -36,14 +36,11 @@ class InlineControlContainer extends \TYPO3\CMS\Backend\Form\Container\InlineCon
 
     protected function getTargetStorageId(): int
     {
-        $storageId = 0;
-        if ((SiteConfigurationResolver::get('canto_enabled_asset_picker') ?? false) === true) {
-            $storageId = (int)SiteConfigurationResolver::get('canto_asset_picker_storage');
-            if ($storageId === 0) {
-                $storages = $this->getStorageRepository()->findByStorageType(CantoDriver::DRIVER_NAME);
-                if (isset($storages[0])) {
-                    $storageId = $storages[0]->getUid();
-                }
+        $storageId = (int)SiteConfigurationResolver::get('canto_enabled_asset_picker', $this->data['effectivePid']);
+        if ($storageId === 0) {
+            $storages = $this->getStorageRepository()->findByStorageType(CantoDriver::DRIVER_NAME);
+            if (isset($storages[0])) {
+                $storageId = $storages[0]->getUid();
             }
         }
         return $storageId;


### PR DESCRIPTION
Opening a record from a group/db type, that contains an image field, needs to parse the returnUrl recursively to get the current page id

Resolves: #5 