### PR TITLE
[BUGFIX] Ensure a public url is returned

### DIFF
--- a/Classes/Resource/EventListener/GeneratePublicUrlForResourceEventListener.php
+++ b/Classes/Resource/EventListener/GeneratePublicUrlForResourceEventListener.php
@@ -12,33 +12,26 @@ declare(strict_types=1);
 namespace TYPO3Canto\CantoFal\Resource\EventListener;
 
 use TYPO3\CMS\Core\Resource\Event\GeneratePublicUrlForResourceEvent;
-use TYPO3\CMS\Core\Resource\File;
 use TYPO3\CMS\Core\Resource\ProcessedFile;
-use TYPO3Canto\CantoFal\Utility\CantoUtility;
+use TYPO3Canto\CantoFal\Resource\Driver\CantoDriver;
 
 final class GeneratePublicUrlForResourceEventListener
 {
     public function __invoke(GeneratePublicUrlForResourceEvent $event): void
     {
         $file = $event->getResource();
-        $identifier = null;
-        if ($file instanceof File) {
-            $identifier = $file->getIdentifier();
-        }
         if ($file instanceof ProcessedFile) {
-            $identifier = $file->getOriginalFile()->getIdentifier();
+            $file = $file->getOriginalFile();
         }
-        if (!$identifier) {
+        if ($file->getStorage()->getDriverType() !== CantoDriver::DRIVER_NAME) {
             return;
         }
         try {
-            if (CantoUtility::isMdcActivated($event->getStorage()->getConfiguration())) {
-                // This applies a public url for the given asset.
-                // If the file has been registered as a mdc-asset, then this returns the url for it
-                // Otherwise we get the url to the downloaded resource instead
-                $url = $event->getDriver()->getPublicUrl($identifier);
-                $event->setPublicUrl($url);
-            }
+            // This applies a public url for the given asset.
+            // If the file has been registered as a mdc-asset, then this returns the url for it
+            // Otherwise we get the url to the downloaded resource instead
+            $url = $event->getDriver()->getPublicUrl($file->getIdentifier());
+            $event->setPublicUrl($url);
         } catch (\InvalidArgumentException $e) {
             // todo: we should add logging in the future
         }


### PR DESCRIPTION
For Canto files it is necessary to use either a MDC url or the directUrlOriginal. As the driver already resolves the MDC setting, the EventListener needs to use its functionality

Resolves: #9 