### PR TITLE
[BUGFIX] Corrected MDC URL generation for image and document schemes in CantoDriver

### DIFF
--- a/Classes/Resource/Driver/CantoDriver.php
+++ b/Classes/Resource/Driver/CantoDriver.php
@@ -161,14 +161,14 @@ class CantoDriver extends AbstractDriver implements StreamableDriverInterface
             return null;
         }
         if ($useMdc && $this->mdcUrlGenerator) {
-            if ($scheme === 'document') {
-                $url = $this->cantoRepository->generateAssetMdcUrl($identifier, $fileData['name']);
-            } else {
+            if ($scheme === 'image') {
                 $url = $this->cantoRepository->generateMdcUrl($identifier);
                 $url .= $this->mdcUrlGenerator->addOperationToMdcUrl([
                     'width' => (int)$fileData['width'],
                     'height' => (int)$fileData['height'],
                 ]);
+            } else {
+                $url = $this->cantoRepository->generateAssetMdcUrl($identifier, $fileData['name']);
             }
 
             return rawurldecode($url);


### PR DESCRIPTION
The canto api (https://api.canto.com/#36910bbd-c42e-485e-8d3e-7d903230066a) states that scheme can be one of "image", "video", "audio", "document", "presentation" or "other". Checking for image to generate the mdc image url and the asset url for all other types makes more sense here.