### PR TITLE
[BUGFIX] Fix passing string instead of int in the initialize method

### DIFF
--- a/Classes/Command/WarmupCantoCache.php
+++ b/Classes/Command/WarmupCantoCache.php
@@ -92,7 +92,7 @@ class WarmupCantoCache extends Command
     {
         $cantoRepository = GeneralUtility::makeInstance(CantoRepository::class);
         $cantoRepository->initialize(
-            (string)$storage->getUid(),
+            $storage->getUid(),
             $storage->getConfiguration()
         );
         return $cantoRepository;

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -81,11 +81,6 @@ parameters:
 			path: Classes/Command/WarmupCantoCache.php
 
 		-
-			message: "#^Parameter \\#1 \\$storageUid of method TYPO3Canto\\\\CantoFal\\\\Resource\\\\Repository\\\\CantoRepository\\:\\:initialize\\(\\) expects int, string given\\.$#"
-			count: 1
-			path: Classes/Command/WarmupCantoCache.php
-
-		-
 			message: "#^Method TYPO3Canto\\\\CantoFal\\\\Controller\\\\MetadataWebhookController\\:\\:getBody\\(\\) return type has no value type specified in iterable type array\\.$#"
 			count: 1
 			path: Classes/Controller/MetadataWebhookController.php


### PR DESCRIPTION
Fixes TYPO3 Exception:

```
Core: Exception handler (CLI): Uncaught TYPO3 Exception: TYPO3Canto\CantoFal\Resource\Repository\CantoRepository::initialize(): Argument #1 ($storageUid) must be of type int, string given, called in /Users/jjacobsen/Sites/canto-dev.internal/vendor/typo3-canto/canto-fal/Classes/Command/WarmupCantoCache.php on line 94 | TypeError thrown in file /Users/jjacobsen/Sites/canto-dev.internal/vendor/typo3-canto/canto-fal/Classes/Resource/Repository/CantoRepository.php in line 82
```