### PR TITLE
[BUGFIX] Wrong $fileRepository parameter in UpdateMetadataAssetsCommand

### DIFF
--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -64,7 +64,7 @@ services:
   TYPO3Canto\CantoFal\Command\UpdateMetadataAssetsCommand:
     arguments:
       - '@TYPO3\CMS\Core\Resource\Service\ExtractorService'
-      - '@TYPO3\CMS\Core\Resource\FileRepository'
+      - '@TYPO3Canto\CantoFal\Resource\Repository\FileRepository'
       - '@TYPO3\CMS\Core\Resource\Index\FileIndexRepository'
       - '@cache.canto_file'
     tags:


### PR DESCRIPTION
Update the parameter in the Services.yaml to the expected class.